### PR TITLE
Delete use_2to3 and bump version

### DIFF
--- a/djangojs/__init__.py
+++ b/djangojs/__init__.py
@@ -3,7 +3,7 @@
 Django.js provide better integration of javascript into Django.
 '''
 
-__version__ = '1.0.3'
+__version__ = '1.0.4'
 __description__ = "Django JS Tools"
 
 #: Packaged jQuery version

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ setup(
     include_package_data=True,
     install_requires=install_requires,
     license='LGPL',
-    use_2to3=True,
     keywords='django javascript test url reverse helpers',
     classifiers=[
         "Framework :: Django",


### PR DESCRIPTION
[setuptools v58.0.0](https://setuptools.readthedocs.io/en/latest/history.html#v58-0-0) removed support for 2to3 during builds
Since SV and Packer already use Python 3 now, there is no need to pass `use_2to3=True` when setup