### PR TITLE
Replace end position anchor `\z`

### DIFF
--- a/djangojs/__init__.py
+++ b/djangojs/__init__.py
@@ -3,7 +3,7 @@
 Django.js provide better integration of javascript into Django.
 '''
 
-__version__ = '2.0.1'
+__version__ = '2.3.0'
 __description__ = "Django JS Tools"
 
 #: Packaged jQuery version

--- a/djangojs/urls_serializer.py
+++ b/djangojs/urls_serializer.py
@@ -87,7 +87,7 @@ def _get_urls_for_pattern(pattern, prefix='', namespace=None):
             if namespace:
                 pattern_name = ':'.join((namespace, pattern_name))
             full_url = prefix + pattern.pattern.regex.pattern
-            for char in ['^', '$']:
+            for char in ['^', '$', '\Z']:
                 full_url = full_url.replace(char, '')
             # remove optionnal non capturing groups
             opt_grp_matches = RE_OPT_GRP.findall(full_url)


### PR DESCRIPTION
support for Django 2.2.
Django 2.2 changed the end position anchor from `$` to `\Z`