### PR TITLE
Support for Django 3 

### DIFF
--- a/djangojs/__init__.py
+++ b/djangojs/__init__.py
@@ -3,7 +3,7 @@
 Django.js provide better integration of javascript into Django.
 '''
 
-__version__ = '2.3.0'
+__version__ = '2.4.0'
 __description__ = "Django JS Tools"
 
 #: Packaged jQuery version

--- a/djangojs/context_serializer.py
+++ b/djangojs/context_serializer.py
@@ -3,10 +3,11 @@ from __future__ import unicode_literals
 
 import json
 import logging
+import six
 
 from django.conf import settings
 from django.template.context import RequestContext
-from django.utils import translation, six
+from django.utils import translation
 
 from djangojs.conf import settings
 from djangojs.utils import LazyJsonEncoder

--- a/djangojs/contrib/social_auth.py
+++ b/djangojs/contrib/social_auth.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from django.utils import six
+import six
+
 from djangojs.context_serializer import ContextSerializer
 
 

--- a/djangojs/templatetags/js.py
+++ b/djangojs/templatetags/js.py
@@ -4,9 +4,10 @@ Provide template tags to help with Javascript/Django integration.
 '''
 from __future__ import unicode_literals
 
+import six
+
 from django import template
 from django.contrib.staticfiles.storage import staticfiles_storage
-from django.utils import six
 from django.utils.safestring import mark_safe
 
 from djangojs import JQUERY_MIGRATE_VERSION

--- a/djangojs/tests/test_context.py
+++ b/djangojs/tests/test_context.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import json
+import six
 
 from django import VERSION as DJANGO_VERSION
 from django.conf import global_settings
@@ -14,7 +15,6 @@ from django.middleware.locale import LocaleMiddleware
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
-from django.utils import six
 from django.utils import translation
 from django.utils import unittest
 

--- a/djangojs/tests/test_urls.py
+++ b/djangojs/tests/test_urls.py
@@ -1,10 +1,10 @@
 import json
+import six
 
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.utils import six
 
 
 class UrlsTestMixin(object):

--- a/djangojs/urls_serializer.py
+++ b/djangojs/urls_serializer.py
@@ -4,12 +4,12 @@ from __future__ import unicode_literals
 import json
 import logging
 import re
+import six
 import sys
 import types
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.urls import URLPattern, URLResolver, get_script_prefix
-from django.utils import six
 
 from djangojs.conf import settings
 


### PR DESCRIPTION
Fix `django.utils.six - Remove usage of this vendored library or switch to six.`